### PR TITLE
Added Gap setting between upper and lower text

### DIFF
--- a/IceBarElement.lua
+++ b/IceBarElement.lua
@@ -171,6 +171,7 @@ function IceBarElement.prototype:GetDefaultSettings()
 	settings["rotateBar"] = false
 	settings["markers"] = {}
 	settings["bAllowExpand"] = true
+	settings["textVerticalGap"] = 0
 
 	return settings
 end
@@ -724,6 +725,26 @@ do
 					order = 11.3,
 				},
 
+				textVerticalGap = {
+					type = 'range',
+					name = L["Text Vertical Gap"],
+					desc = L["Gap between Upper and Lower text vertically"],
+					min = 0,
+					max = 10,
+					step = 1,
+					get = function()
+						return self.moduleSettings.textVerticalGap
+					end,
+					set = function(info, v)
+						self.moduleSettings.textVerticalGap = v
+						self:Redraw()
+					end,
+					disabled = function()
+						return not self.moduleSettings.enabled
+					end,
+					order = 11.4,
+				},
+
 				textHeader = {
 					type = 'header',
 					name = L["Upper Text"],
@@ -1116,8 +1137,13 @@ function IceBarElement.prototype:CreateTexts()
 		offy = self.moduleSettings.textVerticalOffset
 	end
 
+	local offgap = 0
+	if self.moduleSettings.textVerticalGap ~= nil then
+		offgap = self.moduleSettings.textVerticalGap
+	end
+
 	self.frame.bottomUpperText:SetPoint("TOP"..ownPoint , self.frame, "BOTTOM"..parentPoint, offx, offy)
-	self.frame.bottomLowerText:SetPoint("TOP"..ownPoint , self.frame, "BOTTOM"..parentPoint, offx, offy - 14)
+	self.frame.bottomLowerText:SetPoint("TOP"..ownPoint , self.frame, "BOTTOM"..parentPoint, offx, offy - (14 + offgap))
 
 	if (self.moduleSettings.textVisible["upper"]) then
 		self.frame.bottomUpperText:Show()

--- a/loc/enUS.lua
+++ b/loc/enUS.lua
@@ -6,3 +6,6 @@ debug = true
 local L = LibStub("AceLocale-3.0"):NewLocale("IceHUD", "enUS", true, debug)
 
 --@localization(locale="enUS", format="lua_additive_table", same-key-is-true=true, handle-subnamespaces="concat")@
+
+L["Text Vertical Gap"] = true
+L["Gap between Upper and Lower text vertically"] = true


### PR DESCRIPTION
I am using a font size of 18 and I always felt the 2 texts were too close together.

Tested on 7.3 but I don't know how to integrate proper with existing translations.

I hope the PR is to your liking.