### PR TITLE
add missing unit parameter on SpellCastFailed

### DIFF
--- a/IceCastBar.lua
+++ b/IceCastBar.lua
@@ -470,7 +470,7 @@ function IceCastBar.prototype:SpellCastStop(event, unit, castGuid, spellId)
 end
 
 
-function IceCastBar.prototype:SpellCastFailed(event, castGuid, spellId)
+function IceCastBar.prototype:SpellCastFailed(event, unit, castGuid, spellId)
 	if (unit ~= self.unit) then return end
 	IceHUD:Debug("SpellCastFailed", unit, castGuid, spellId)
 


### PR DESCRIPTION
unit wasn't being collected as an argument on SpellCastFailed, but is being checked within the function.