### PR TITLE
add TargetCast support in Classic [fixed]

### DIFF
--- a/modules/TargetCast.lua
+++ b/modules/TargetCast.lua
@@ -65,7 +65,12 @@ function TargetCast.prototype:GetDefaultSettings()
 	settings["side"] = IceCore.Side.Right
 	settings["offset"] = 3
 	settings["flashInstants"] = "Never"
-	settings["flashFailures"] = "Never"
+	-- Fulzamoth 2019-09-27 : let the flash handler work if in Classic and LibClassicCasterino exists
+	if LibClassicCasterino then
+		settings["flashFailures"] = ""
+	else
+		settings["flashFailures"] = "Never"
+	end 
 	settings["shouldAnimate"] = false
 	settings["hideAnimationSettings"] = true
 	settings["usesDogTagStrings"] = false
@@ -197,7 +202,8 @@ end
 -------------------------------------------------------------------------------
 
 
+-- Fulzamoth 2019-09-27 : load in Classic if LibClassicCasterino exists
 -- Load us up
-if not IceHUD.WowClassic then
+if not IceHUD.WowClassic or LibClassicCasterino then
 	IceHUD.TargetCast = TargetCast:new()
 end


### PR DESCRIPTION
This change adds support for using LibCasterCasterino to get your
target's casting info to enable the TargetCast module. It's not as
clean as the newer retail native calls but works well enough for
most interrupts.

Note: because LibCasterCasterino is using combat log events to get
casting info if a spell cast starts and is immediately cancelled or
interrupted the log may not get updated and the cast bar will zombie
complete.

LibCasterCasterino can be found at:

https://github.com/rgd87/LibClassicCasterino