### PR TITLE
Add Spell ID support for aura tracking

### DIFF
--- a/IceHUD.lua
+++ b/IceHUD.lua
@@ -36,7 +36,7 @@ else
 end
 
 -- compatibility/feature flags
-IceHUD.GetPlayerAuraBySpellID = IceHUD.WowMain and IceHUD.WowVer > 90000
+IceHUD.GetPlayerAuraBySpellID = _G["C_UnitAuras"] and C_UnitAuras.GetPlayerAuraBySpellID
 IceHUD.SpellFunctionsReturnRank = IceHUD.WowMain and IceHUD.WowVer < 80000
 IceHUD.EventExistsPlayerPetChanged = IceHUD.WowMain and IceHUD.WowVer < 80000
 IceHUD.EventExistsPetBarChanged = IceHUD.WowMain and IceHUD.WowVer < 80000

--- a/IceHUD.lua
+++ b/IceHUD.lua
@@ -36,6 +36,7 @@ else
 end
 
 -- compatibility/feature flags
+IceHUD.GetPlayerAuraBySpellID = IceHUD.WowMain and IceHUD.WowVer > 90000
 IceHUD.SpellFunctionsReturnRank = IceHUD.WowMain and IceHUD.WowVer < 80000
 IceHUD.EventExistsPlayerPetChanged = IceHUD.WowMain and IceHUD.WowVer < 80000
 IceHUD.EventExistsPetBarChanged = IceHUD.WowMain and IceHUD.WowVer < 80000
@@ -492,6 +493,16 @@ function IceHUD:GetAuraCount(auraType, unit, ability, onlyMine, matchByName)
 		end
 
 		return 0
+	end
+
+	-- Support for Spell IDs
+	if (IceHUD.GetPlayerAuraBySpellID and tonumber(ability) ~= nil) then
+		local aura = C_UnitAuras.GetPlayerAuraBySpellID(ability)
+		if aura ~= nil then
+			return aura.applications
+		else
+			return 0
+		end
 	end
 
 	local i = 1

--- a/IceStackCounter.lua
+++ b/IceStackCounter.lua
@@ -52,7 +52,13 @@ function IceStackCounter_GetOptions(frame, opts)
 	opts["auraName"] = {
 		type = 'input',
 		name = L["Aura to track"],
-		desc = L["Which buff/debuff this counter will be tracking. \n\nRemember to press ENTER after filling out this box with the name you want or it will not save."],
+		desc = function()
+			if IceHUD.GetPlayerAuraBySpellID then
+				return L["Which buff/debuff this counter will be tracking. Can use the name or spell id. \n\nRemember to press ENTER after filling out this box with the name you want or it will not save."]
+			else
+				return L["Which buff/debuff this counter will be tracking. \n\nRemember to press ENTER after filling out this box with the name you want or it will not save."]
+			end
+		end,
 		get = function()
 			return frame.moduleSettings.auraName
 		end,

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+v1.14.3:
+
+- Add Spell ID support for aura tracking.
+
 v1.14.2:
 
 - Fix CC and Invuln modules not showing immediately when they should.

--- a/modules/CustomBar.lua
+++ b/modules/CustomBar.lua
@@ -329,16 +329,18 @@ function IceCustomBar.prototype:GetOptions()
 	opts["buffToTrack"] = {
 		type = 'input',
 		name = L["Aura to track"],
-		desc = L["Which buff/debuff this bar will be tracking.\n\nRemember to press ENTER after filling out this box with the name you want or it will not save."],
+		desc = function()
+			if IceHUD.GetPlayerAuraBySpellID then
+				return L["Which buff/debuff this bar will be tracking. Can use the name or spell id. \n\nRemember to press ENTER after filling out this box with the name you want or it will not save."]
+			else
+				return L["Which buff/debuff this bar will be tracking.\n\nRemember to press ENTER after filling out this box with the name you want or it will not save."]
+			end
+		end,
 		get = function()
 			return self.moduleSettings.buffToTrack
 		end,
 		set = function(info, v)
 			local orig = v
-			--Parnic: we now allow spell IDs to be used directly
-			--if tonumber(v) ~= nil then
-			--	v = GetSpellInfo(tonumber(v))
-			--end
 			if v == nil then
 				v = orig
 			end

--- a/this_version.md
+++ b/this_version.md
@@ -1,5 +1,9 @@
 # Changelog
 
+v1.14.3:
+
+- Add Spell ID support for aura tracking.
+
 v1.14.2:
 
 - Fix CC and Invuln modules not showing immediately when they should.


### PR DESCRIPTION
I've been testing on my Shadow Priest with the new Coalescing Shadows buffs (IDs 391243 and 391244) and this code is working. I also added a new compatibility flag because the function I'm using, GetPlayerAuraBySpellID, was added in 9.0.1. The flag is used for the hover description for "Aura to track" also so that it specifies that a user can use a spell ID.