### PR TITLE
using table.remove to not leave a hole in the array

### DIFF
--- a/modules/TargetInfo.lua
+++ b/modules/TargetInfo.lua
@@ -1453,7 +1453,7 @@ function IceTargetInfo.prototype:UpdateBuffType(aura)
 				end
 			else
 				self.frame[auraFrame].iconFrames[i]:Hide()
-				buffData[aura][i] = nil
+				table.remove(buffData[aura], i)
 			end
 		end
 	end


### PR DESCRIPTION
I've only gotten  in one run of H++ AN for testing but I didn't have any lua errors with this change (usually i see multiple on Anub'arak alone) no any other side effects I believe this works.