### PR TITLE
Changes for Patch 11.2

### DIFF
--- a/modules/PlayerHealth.lua
+++ b/modules/PlayerHealth.lua
@@ -1186,7 +1186,7 @@ end
 
 
 function PlayerHealth.prototype:CheckLootMaster()
-	local _, lootmaster = GetLootMethod()
+	local _, lootmaster = C_PartyInfo.GetLootMethod()
 	if configMode or lootmaster == 0 then
 		if (configMode or self.moduleSettings.showLootMasterIcon) and not self.frame.lootMasterIcon then
 			self.frame.lootMasterIcon = self:CreateTexCoord(self.frame.lootMasterIcon, "Interface\\GroupFrame\\UI-Group-MasterLooter", 20, 20,


### PR DESCRIPTION
GetLootMethod() is now under C_PartyInfo.
Source: https://warcraft.wiki.gg/wiki/API_C_PartyInfo.GetLootMethod