### PR TITLE
Buff timer toggle

### DIFF
--- a/modules/TargetInfo.lua
+++ b/modules/TargetInfo.lua
@@ -1540,7 +1540,7 @@ function IceTargetInfo.prototype:SetupAura(aura, i, icon, duration, expirationTi
 	frameIcon.texture:SetTexture(icon)
 	frameIcon.texture:SetTexCoord(zoom, 1-zoom, zoom, 1-zoom)
 	frameIcon.stack:SetText((count and (count > 1)) and count or nil)
-	
+
 	frame:Show()
 end
 


### PR DESCRIPTION
Added option for enable/disable of countdown timers on buffs and debuffs in the targetinfo panel.  

Something changed recently in Blizzard's UI that caused the countdown timer text on buffs and debuffs to automatically show up in the target info panels, obscuring the icons and making it difficult to discern which buffs/debuffs were which.  This change adds an additional configuration option to the target info panel to allow players to toggle these timers on/off if they wish. By default it's turned off.

